### PR TITLE
Add export default types at package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "exports": {
     ".": {
       "require": "./lib/index.cjs",
-      "import": "./lib/index.mjs"
+      "import": "./lib/index.mjs",
+      "types": "./lib/index.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
> First of all, Thanks `cjk-slug`.  I am using `cjk-slug` very well! 😄 

I created **native esm with typescript** project. and I imported `cjk-slug` in typescript file. but `d.ts` cannot imported.

**package.json**
```json
{
  ...
  "type": "module"
  ...
}
```

**tsconfig.json**
```json
{
  "compilerOptions": {
    ...
    /* Language and Environment */
    "target": "ESNext" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,

    /* Modules */
    "module": "NodeNext" /* Specify what module code is generated. */,
    "moduleResolution": "NodeNext" /* Specify how TypeScript looks up a file from a given module specifier. */,
    ...
  }
}

```

![image](https://user-images.githubusercontent.com/61136724/190602956-0ad2a623-6259-4c1c-b4bb-7493b282a51e.png)

so, I searched a [document](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing).

as the document, I tried to update export map for `d.ts`.
```json
"exports": {
    ".": {
      "require": {
        "types": "./lib/index.d.ts",
        "default": "./lib/index.cjs"
      },
      "import": {
        "types": "./lib/index.d.ts",
        "default": "./lib/index.mjs"
      },
      "types": "./lib/index.d.ts"
    },
    "./package.json": "./package.json"
  },
```

but I failed `build` for using export conditional object which have types.
```bash
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received an instance of Object
```

so I added export default types.

```json
"exports": {
    ".": {
      "require": "./lib/index.cjs",
      "import": "./lib/index.mjs",
      "types": "./lib/index.d.ts"
    },
    "./package.json": "./package.json"
  },
```

This may not good answer for the issue. but I hope it helps through this pr.


