### PR TITLE
feat(build): Change nanobundle minify option (false -> default:true)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "prepack": "yarn build",
     "test": "uvu -r tsm",
-    "build": "nanobundle build --minify=false"
+    "build": "nanobundle build"
   },
   "dependencies": {
     "normalize-cjk": "^0.4.0"


### PR DESCRIPTION
looks like the bundle size can be reduced by about 30%, compared to the current.

<table>
<tr>
<th>build with minify=false</th>
<th>build with minify=true (default)</th>
</tr>

<tr>
<td>

```sh
ESM entry ./lib/index.mjs
    size      : 572 B
    size (gz) : 331 B
    size (br) : 284 B

CommonJS entry ./lib/index.cjs for Node.js
    size      : 1.89 kB
    size (gz) : 819 B
    size (br) : 722 B
```
</td>
<td>

```sh
ESM entry ./lib/index.mjs
    size      : 399 B
    size (gz) : 268 B
    size (br) : 219 B

CommonJS entry ./lib/index.cjs for Node.js
    size      : 972 B
    size (gz) : 568 B
    size (br) : 496 B
```
</td>
</tr>
</table>
